### PR TITLE
Resolve broken external links build failure

### DIFF
--- a/playbooks/app_dev/binary_deployment_howto.adoc
+++ b/playbooks/app_dev/binary_deployment_howto.adoc
@@ -12,7 +12,7 @@ Here I am going to walk through the steps to do a simple binary deployment to To
 
 - A WAR file
 - An OpenShift Environment running 3.1.1 or later
-- The `oc` (OpenShift Client) utility. link:https://docs.openshift.com/enterprise/3.1/cli_reference/get_started_cli.html#installing-the-cli[Install Instructions here].
+- The `oc` (OpenShift Client) utility. link:https://docs.openshift.com/container-platform/latest/cli_reference/get_started_cli.html#installing-the-cli[Install Instructions here].
 
 == Local Setup
 
@@ -36,7 +36,7 @@ In order to simplify the URL structure for my application, I'm going to rename m
 ROOT.war
 ----
 
-Now, when I deploy to the link:https://docs.openshift.com/enterprise/3.1/using_images/xpaas_images/jws.html[OpenShift Tomcat 8 Image], it's going to expect my warfile to be in a `deployments` directory, so I'm going to do that as well.
+Now, when I deploy to the link:https://access.redhat.com/documentation/en/red-hat-xpaas/0/single/red-hat-xpaas-jboss-web-server-image/[OpenShift Tomcat 8 Image], it's going to expect my warfile to be in a `deployments` directory, so I'm going to do that as well.
 
 [source,bash]
 ----
@@ -87,7 +87,7 @@ Now, I'm about ready to deploy my app. A Binary Deployment in OpenShift consists
 So for the build step, I require a few things:
 
 - My local WAR file
-- The name of the link:https://docs.openshift.com/enterprise/3.1/architecture/core_concepts/builds_and_image_streams.html#image-streams[ImageStream] for the image I want to deploy to. In this case, tomact 8.
+- The name of the link:https://docs.openshift.com/container-platform/latest/architecture/core_concepts/builds_and_image_streams.html#image-streams[ImageStream] for the image I want to deploy to. In this case, tomact 8.
 
 Since I already have my WAR file ready, I just need to find the right ImageStream to use. By default, OpenShift stores all of it's ImageStreams in a globally readable project called `openshift`, so I'll just do a search there for `tomcat8`.
 

--- a/playbooks/app_dev/builds.adoc
+++ b/playbooks/app_dev/builds.adoc
@@ -7,9 +7,9 @@ v1.0, 2015-09-15
 :toc-title:
 
 toc::[]
-[quote, OpenShift Builds, https://docs.openshift.com/enterprise/3.0/architecture/core_concepts/builds_and_image_streams.html#builds]
+[quote, OpenShift Builds, https://docs.openshift.com/container-platform/latest/architecture/core_concepts/builds_and_image_streams.html#builds]
 _________________________________________________
-A build is the process of transforming input parameters into a resulting object
+A build is the process of transforming input parameters into a resulting object.
 _________________________________________________
 
 
@@ -78,8 +78,8 @@ A Docker build in OpenShift is similar to a Docker build in a standalone environ
 
 
 ==== Additional Resources
-* https://docs.docker.com/reference/builder/[Dockerfile]
-** https://docs.docker.com/articles/dockerfile_best-practices/[Dockerfile Best Practices]
+* https://docs.docker.com/engine/reference/builder/[Dockerfile]
+** https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/[Dockerfile Best Practices]
 
 Docker Build in a BuildConfig
 The following is a snippet of code demonstrating the use of a Docker build in a BuildConfig
@@ -146,7 +146,7 @@ The following is a snippet of code demonstrating the use of a Docker build in a 
 
 == Source to Image (S2I)
 
-[quote, S2I Requirements, https://docs.openshift.com/enterprise/3.0/creating_images/s2i.html]
+[quote, S2I Requirements, https://docs.openshift.com/container-platform/latest/creating_images/s2i.html]
 _________________________________________________
 Source-to-Image (S2I) is a framework that makes it easy to write images that take application source code as an input and produce a new image that runs the assembled application as output.
 _________________________________________________
@@ -277,7 +277,7 @@ Values can be injected into S2I scripts to enable dynamic configuration for a pa
 Several of the builder images utilize environment variable to drive their execution. Examples include setting the location of a proxy server using the `HTTP_PROXY` variable or to set Maven arguments using the `MAVEN_ARGS` variable.
 
 ===== Additional Resources
-* https://docs.openshift.com/enterprise/3.0/creating_images/s2i.html#s2i-scripts[S2I Scripts]
+* https://docs.openshift.com/container-platform/latest/creating_images/s2i.html#s2i-scripts[S2I Scripts]
 
 ==== S2I within Applications
 
@@ -331,7 +331,7 @@ There are a number of existing S2I builders that you can look to leverage for yo
 
 * https://github.com/openshift/source-to-image/blob/master/README.md#installation[Installation]
 * https://github.com/openshift/source-to-image/blob/master/docs/cli.md[CLI]
-* https://docs.openshift.com/enterprise/3.0/creating_images/s2i_testing.html[Testing]
+* https://docs.openshift.com/container-platform/latest/creating_images/s2i_testing.html[Testing]
 * https://blog.openshift.com/create-s2i-builder-image/[Creating an S2I Builder Image]
 
 

--- a/playbooks/continuous_delivery/image_promotion.adoc
+++ b/playbooks/continuous_delivery/image_promotion.adoc
@@ -20,7 +20,7 @@ Each strategy defined within this document will have several consistent themes:
 ** It is _recommended_ that the Jenkins CI server be used to facilitate the promotion process, however standalone scripts may be used instead if desired
 Docker client to manipulate images
 
-NOTE: The user executing the scripts must be a member of the docker group in order to access the Docker socket. Additional information on this topic can be found https://docs.docker.com/installation/fedora/[here]
+NOTE: The user executing the scripts must be a member of the docker group in order to access the Docker socket. Additional information on this topic can be found https://docs.docker.com/engine/installation/linux/fedora/[here]
 
 == Prerequisites
 

--- a/playbooks/fundamentals/devops_reading_list.adoc
+++ b/playbooks/fundamentals/devops_reading_list.adoc
@@ -16,6 +16,7 @@ To that end, we have compiled a reading list to get you familiar with this philo
 We recommend starting here. The following references help to answer the question, "What is DevOps?" and provide a base of knowledge on which to build.
 
 * link:http://itrevolution.com/books/phoenix-project-devops-book/[The Phoenix Project] (Book)
+* link:http://itrevolution.com/devops-handbook[The DevOps Handbook] (Book)
 * link:http://itrevolution.com/the-convergence-of-devops/[The Convergence of DevOps] (Article)
 * link:http://itrevolution.com/the-three-ways-principles-underpinning-devops/[The Three Ways: The Principles Underpinning DevOps] (Article)
 

--- a/playbooks/fundamentals/docker_reference.adoc
+++ b/playbooks/fundamentals/docker_reference.adoc
@@ -26,5 +26,5 @@ toc::[]
 
 == OpenShift Specific Guidance for Images
 
-* link:https://docs.openshift.com/enterprise/latest/creating_images/guidelines.html[Guidelines for Creating OpenShift Images]
-* link:https://docs.openshift.com/enterprise/latest/creating_images/custom.html[Building Custom S2I Builder Images]
+* link:https://docs.openshift.com/container-platform/latest/creating_images/guidelines.html[Guidelines for Creating OpenShift Images]
+* link:https://docs.openshift.com/container-platform/latest/creating_images/custom.html[Building Custom S2I Builder Images]

--- a/playbooks/installation/disconnected_environments.adoc
+++ b/playbooks/installation/disconnected_environments.adoc
@@ -15,7 +15,7 @@ There are at least three considerations for enterprise environments:
 
 === Assumptions
 
-This document assumes that you understand the overall architecture of OpenShift 3 and that you have already planned out what the topology of your environment will look like. If you do not have a thorough understanding of the architecture of OpenShift 3, the service layer, projects, and how topologies are configured via the scheduler, there are steps in this document that may not make sense. For more information, see https://docs.openshift.com/enterprise/3.0/architecture/overview.html[OSE 3 Architecture Overview]. This document also assumes that you have some understanding of Docker, registries, and Docker’s command line tools.
+This document assumes that you understand the overall architecture of OpenShift 3 and that you have already planned out what the topology of your environment will look like. If you do not have a thorough understanding of the architecture of OpenShift 3, the service layer, projects, and how topologies are configured via the scheduler, there are steps in this document that may not make sense. For more information, see https://docs.openshift.com/container-platform/latest/architecture/overview.html[OSE 3 Architecture Overview]. This document also assumes that you have some understanding of Docker, registries, and Docker’s command line tools.
 
 === Required Software and Components
 
@@ -275,9 +275,10 @@ Place the following text in the file:
 ==== Host Preparation
 
 At this point, the systems are ready to continue to be prepared following the OpenShift documentation. See the following section:
-https://access.redhat.com/documentation/en/openshift-enterprise/version-3.0/openshift-enterprise-30-installation-and-configuration/chapter-2-installing#host-preparation
 
-Skip the section titled “Registering the Hosts” and start with “Managing Base Packages”.
+* link:https://docs.openshift.com/container-platform/latest/install_config/install/host_preparation.html[Host Preparation]
+
+Skip the section titled “Host Registration” and start with “Installing Base Packages”.
 
 === OpenShift Installation
 
@@ -299,13 +300,13 @@ On one of the hosts that will cat as an OpenShift Master, copy and import the bu
 
 You may now follow the rest of the OpenShift installation instructions in the documentation. See the following section:
 
-https://access.redhat.com/documentation/en/openshift-enterprise/version-3.0/installation-and-configuration/#advanced-installation
+* link:https://docs.openshift.com/container-platform/latest/install_config/install/advanced_install.html[Advanced Installation]
 
 ==== Create the Internal Docker Registry
 
 You now need to create the internal Docker registry. See the following section of the documentation:
 
-https://access.redhat.com/documentation/en/openshift-enterprise/version-3.0/installation-and-configuration/#deploying-a-docker-registry
+* link:https://docs.openshift.com/container-platform/latest/install_config/registry/deploy_registry_existing_clusters.html[Deploy Internal Docker Registry]
 
 === Post-Installation Changes
 
@@ -441,7 +442,8 @@ The tags (6.2-140,6.2-84,latest + 2 more...) should not be empty.
 
 At this point the OpenShift environment is almost ready for use. It is likely that you will want to install and configure a router, documented here:
 
-https://access.redhat.com/documentation/en/openshift-enterprise/version-3.0/installation-and-configuration/#deploying-a-router
+* link:https://docs.openshift.com/container-platform/latest/install_config/router/index.html[Router Overview]
+* link:https://docs.openshift.com/container-platform/latest/install_config/router/default_haproxy_router.html[Default HAProxy Router]
 
 Other than that, your OpenShift environment is ready for use.
 

--- a/playbooks/installation/installation.adoc
+++ b/playbooks/installation/installation.adoc
@@ -17,7 +17,7 @@ The OpenShift Container Platform Smart Start is a reference architecture for a H
 
 image::/images/ocp_smart_start_diagram.png[Smart Start Architecture]
 
-The diagram above depicts the architecture of the Smart Start environment. It consists of 3 Masters and 5 Nodes. We further subdivide the nodes into two groups. Two of them get designated to run OpenShift's router and image registry. We refer to these as _Infrastructure Nodes_. The other three will run the actual application workloads. We call these _Application Nodes_ or _Compute Nodes_. In order to designate which nodes will do which job, we assign link:https://docs.openshift.com/enterprise/3.2/architecture/core_concepts/pods_and_services.html#labels[labels] to them, which will be used by the OpenShift/Kubernetes link:https://docs.openshift.com/enterprise/3.2/admin_guide/scheduler.html[scheduler] to assign certain workload types to each (i.e. "infra" workloads vs "primary" workloads). See the sample inventory file at the bottom of this doc to see how those labels are assigned.
+The diagram above depicts the architecture of the Smart Start environment. It consists of 3 Masters and 5 Nodes. We further subdivide the nodes into two groups. Two of them get designated to run OpenShift's router and image registry. We refer to these as _Infrastructure Nodes_. The other three will run the actual application workloads. We call these _Application Nodes_ or _Compute Nodes_. In order to designate which nodes will do which job, we assign link:https://docs.openshift.com/container-platform/latest/architecture/core_concepts/pods_and_services.html#labels[labels] to them, which will be used by the OpenShift/Kubernetes link:https://docs.openshift.com/container-platform/latest/admin_guide/scheduler.html[scheduler] to assign certain workload types to each (i.e. "infra" workloads vs "primary" workloads). See the sample inventory file at the bottom of this doc to see how those labels are assigned.
 
 NOTE: For more information on these concepts and components, see our link:/playbooks/fundamentals/building_blocks_openshift{outfilesuffix}[Building Blocks of OpenShift] doc.
 
@@ -82,7 +82,7 @@ Additionally, the following is assumed about the environment OpenShift is being 
 * An external DNS infrastructure is available for creating hostnames for the servers, as well as a wildcard entry for application traffic routing
 * An external storage infrastructure capable of providing NFS volumes
 
-NOTE: For more information, see the link:https://docs.openshift.com/enterprise/latest/install_config/install/prerequisites.html[Official Documentation regarding OpenShift Installation Prerequisites].
+NOTE: For more information, see the link:https://docs.openshift.com/container-platform/latest/install_config/install/prerequisites.html[Official Documentation regarding OpenShift Installation Prerequisites].
 
 === Configure DNS
 
@@ -95,7 +95,7 @@ At a minimum the following needs to be true for all OpenShift hosts:
 * Each server can ping all other servers via a hostname in DNS (no /etc/hosts entries)
 * A wildcard DNS entry exists under a unique subdomain (i.e. `*.cloudapps.example.com`) that resolves to either the IP addresses (an A record) or the hostnames (a CNAME record) of the two _Infrastructure Nodes_
 
-NOTE: For more information, see the link:https://docs.openshift.com/enterprise/latest/install_config/install/prerequisites.html#prereq-dns[Official Documentation Regarding DNS Requirements].
+NOTE: For more information, see the link:https://docs.openshift.com/container-platform/latest/install_config/install/prerequisites.html#prereq-dns[Official Documentation Regarding DNS Requirements].
 
 
 == Prepare Hosts for Install
@@ -116,19 +116,19 @@ Overall requirements for Installing OpenShift are very simple:
 * Install the following extra packages: `yum install wget git net-tools bind-utils iptables-services bridge-utils`
 * Optional: install the following diagnostic tools: `yum install lsof strace nc telnet`
 * Fully update all packages: `yum -y update`
-* Sync SSH keys from masters to all nodes (Here's how: https://docs.openshift.com/enterprise/latest/install_config/install/prerequisites.html#ensuring-host-access)
+* Sync SSH keys from masters to all nodes (Here's how: https://docs.openshift.com/container-platform/latest/install_config/install/prerequisites.html#ensuring-host-access)
 
-NOTE: For more information, see the link:https://docs.openshift.com/enterprise/latest/install_config/install/prerequisites.html#host-preparation[Official Documenation for Host Preparation].
+NOTE: For more information, see the link:https://docs.openshift.com/container-platform/latest/install_config/install/prerequisites.html#host-preparation[Official Documenation for Host Preparation].
 
 == Configure and Run the Ansible Installer
 
-We highly recommend using the link:https://docs.openshift.com/enterprise/latest/install_config/install/advanced_install.html#installing-ansible[Advanced Installation method using Ansible] for basically any multi-node installation. The OpenShift Quick Installer is available and useful for quick demos and short-lived installs, but does not support the customization needed to install in many real environments.
+We highly recommend using the link:https://docs.openshift.com/container-platform/latest/install_config/install/advanced_install.html#installing-ansible[Advanced Installation method using Ansible] for basically any multi-node installation. The OpenShift Quick Installer is available and useful for quick demos and short-lived installs, but does not support the customization needed to install in many real environments.
 
 The instructions in the Installer Guide will get you through most basic installs, but there are few additional things to know and be aware of to really understand the installer.
 
 === The Ansible Inventory File
 
-While the Install Guide shows some basic examples for link:https://docs.openshift.com/enterprise/latest/install_config/install/advanced_install.html#configuring-ansible[Configuring Ansible Hosts], there are many more options and variables that can be used to further customize your install. We attempt to break down a few of the common ones here.
+While the Install Guide shows some basic examples for link:https://docs.openshift.com/container-platform/latest/install_config/install/advanced_install.html#configuring-ansible[Configuring Ansible Hosts], there are many more options and variables that can be used to further customize your install. We attempt to break down a few of the common ones here.
 
 ==== Explicitly Set Hostnames and IPs
 

--- a/playbooks/installation/ldap_integration.adoc
+++ b/playbooks/installation/ldap_integration.adoc
@@ -265,11 +265,11 @@ _Here the error: error: validation of LDAP sync config failed: groupsQuery.filte
 ----
 
 == References
-https://docs.openshift.com/enterprise/3.0/admin_guide/configuring_authentication.html#LDAPPasswordIdentityProvider[OpenShift LDAP Authentication Reference]
+https://docs.openshift.com/container-platform/latest/install_config/configuring_authentication.html#LDAPPasswordIdentityProvider[OpenShift LDAP Authentication Reference]
 
-https://docs.openshift.com/enterprise/3.1/install_config/syncing_groups_with_ldap.html[Syncing LDAP Groups]
+https://docs.openshift.com/container-platform/latest/install_config/syncing_groups_with_ldap.html[Syncing LDAP Groups]
 
-http://ldapwiki.willeke.com/wiki/LDAP%20Query%20Examples[LDAP Query Examples]
+https://access.redhat.com/documentation/en-US/Red_Hat_Directory_Server/10/html/Administration_Guide/Examples-of-common-ldapsearches.html[LDAP Query Examples]
 
 http://www.openldap.org/faq/data/cache/185.html[Configuring OpenLDAP TLS]
 

--- a/playbooks/installation/load_balancing.adoc
+++ b/playbooks/installation/load_balancing.adoc
@@ -67,7 +67,7 @@ Requirements for a Full Integration include:
 ** Create virtual hosts
 ** Delete virtual hosts
 ** Add and configure certificates
-* One or more link:https://docs.openshift.com/container-platform/latest/admin_guide/routing_from_edge_lb.html#establishing-a-tunnel-using-a-ramp-node[OpenShift Ramp Nodes] by which access to the internal SDN is provided to the BIG-IP(TM)
+* One or more link:https://docs.openshift.com/container-platform/latest/install_config/routing_from_edge_lb.html#establishing-a-tunnel-using-a-ramp-node[OpenShift Ramp Nodes] by which access to the internal SDN is provided to the BIG-IP(TM)
 
 In this way, the OpenShift router pods work as configuration agents for the F5. Rather than handling incoming web traffic, the pods just watch the OpenShift API for new routes to be created and pass that configuration information up to the F5 via its API to configure routes and handle traffic at the load balancer level.
 

--- a/playbooks/installation/load_balancing.adoc
+++ b/playbooks/installation/load_balancing.adoc
@@ -67,18 +67,18 @@ Requirements for a Full Integration include:
 ** Create virtual hosts
 ** Delete virtual hosts
 ** Add and configure certificates
-* One or more link:https://docs.openshift.com/enterprise/3.0/admin_guide/routing_from_edge_lb.html#establishing-a-tunnel-using-a-ramp-node[OpenShift Ramp Nodes] by which access to the internal SDN is provided to the BIG-IP(TM)
+* One or more link:https://docs.openshift.com/container-platform/latest/admin_guide/routing_from_edge_lb.html#establishing-a-tunnel-using-a-ramp-node[OpenShift Ramp Nodes] by which access to the internal SDN is provided to the BIG-IP(TM)
 
 In this way, the OpenShift router pods work as configuration agents for the F5. Rather than handling incoming web traffic, the pods just watch the OpenShift API for new routes to be created and pass that configuration information up to the F5 via its API to configure routes and handle traffic at the load balancer level.
 
 Through the use of tunnels provided by ramp nodes, the F5 BIG-IP(TM) is given the ability to directly send traffic to OpenShift pods.
 
-TIP: By default, the use of a Ramp Node creates a single point of failure. To avoid this, you must configure a link:https://docs.openshift.com/enterprise/3.1/install_config/routing_from_edge_lb.html#establishing-a-tunnel-using-a-ramp-node[highly available ramp node].
+TIP: By default, the use of a Ramp Node creates a single point of failure. To avoid this, you must configure a link:https://docs.openshift.com/container-platform/latest/install_config/routing_from_edge_lb.html#establishing-a-tunnel-using-a-ramp-node[highly available ramp node].
 
 image::/images/load_balancing_full.jpg[Full Integration]
 
 For more information on configuration, view the routing section of the official OpenShift Enterprise docs:
-https://docs.openshift.com/enterprise/3.1/install_config/install/deploy_router.html#deploying-the-f5-router
+https://docs.openshift.com/container-platform/latest/install_config/router/f5_router.html
 
 == Load Balancing For HA Master Infrastructure
 
@@ -104,7 +104,7 @@ image::/images/load_balancing_masters_simple.png[Simple Passthrough for OpenShif
 * Domain Name for VIP registered in DNS
   ** Domain name will become value of both `openshift_master_cluster_public_hostname` and `openshift_master_cluster_hostname` in OpenShift Installer
   ** For this example, we will give our VIP an FQDN: *paas.myorg.com*
-* Master hosts created and prepped per link:https://docs.openshift.com/enterprise/3.1/install_config/install/prerequisites.html[Install Prerequisites]
+* Master hosts created and prepped per link:https://docs.openshift.com/container-platform/latest/install_config/install/prerequisites.html[Install Prerequisites]
 
 For the purposes of this example, we will use the hosts specified in the table below
 
@@ -183,7 +183,7 @@ node02.myorg.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
 
 ===== 3. Run the Advanced Installer
 
-Run the installer per the instructions in the link:https://docs.openshift.com/enterprise/3.1/install_config/install/advanced_install.html#running-the-advanced-installation[Advanced Insallation Guide]
+Run the installer per the instructions in the link:https://docs.openshift.com/container-platform/latest/install_config/install/advanced_install.html#running-the-advanced-installation[Advanced Insallation Guide]
 
 === Custom Certificate SSL Termination (Production)
 
@@ -211,7 +211,7 @@ image::/images/load_balancing_masters_prod.png[Production Ready Load Balancing f
 * FQDN for each VIP registered in DNS
   ** FQDN for _external_ VIP will become value of `openshift_master_cluster_public_hostname` in OpenShift Installer (i.e. paas.myorg.com)
   ** FQDN for _internal_ VIP will become value of `openshift_master_cluster_hostname` in OpenShift Installer (i.e. paas-internal.myorg.com)
-* Master hosts created and prepped per link:https://docs.openshift.com/enterprise/3.1/install_config/install/prerequisites.html[Install Prerequisites]
+* Master hosts created and prepped per link:https://docs.openshift.com/container-platform/latest/install_config/install/prerequisites.html[Install Prerequisites]
 
 For the purposes of this example, we will use the hosts specified in the table below
 
@@ -326,4 +326,4 @@ node02.myorg.com openshift_node_labels="{'region': 'primary', 'zone': 'west'}"
 
 ===== 3. Run the Advanced Installer
 
-Run the installer per the instructions in the link:https://docs.openshift.com/enterprise/3.1/install_config/install/advanced_install.html#running-the-advanced-installation[Advanced Installation Guide]
+Run the installer per the instructions in the link:https://docs.openshift.com/container-platform/latest/install_config/install/advanced_install.html#running-the-advanced-installation[Advanced Installation Guide]

--- a/playbooks/installation/logging.adoc
+++ b/playbooks/installation/logging.adoc
@@ -31,7 +31,7 @@ Need some examples of forwarding OpenShift logs using rsyslog.
 
 ==== Centralizing Logs with Fluentd
 
-The OpenShift 3.0 Documentation provides a way to link:https://docs.openshift.com/container-platform/latest/admin_guide/aggregate_logging.html[use Fluentd to capture and centralize container logs]. This implementation is fairly limiting though as it doesn't fully parse the log files and capture metadata like namespaces, pods names, etc.
+The OpenShift 3.0 Documentation provides a way to link:https://docs.openshift.com/container-platform/latest/install_config/aggregate_logging.html[use Fluentd to capture and centralize container logs]. This implementation is fairly limiting though as it doesn't fully parse the log files and capture metadata like namespaces, pods names, etc.
 
 ==== Full Metadata Supported Log Aggregation with Fluentd
 

--- a/playbooks/installation/logging.adoc
+++ b/playbooks/installation/logging.adoc
@@ -31,7 +31,7 @@ Need some examples of forwarding OpenShift logs using rsyslog.
 
 ==== Centralizing Logs with Fluentd
 
-The OpenShift 3.0 Documentation provides a way to link:https://docs.openshift.com/enterprise/3.0/admin_guide/aggregate_logging.html[use Fluentd to capture and centralize container logs]. This implementation is fairly limiting though as it doesn't fully parse the log files and capture metadata like namespaces, pods names, etc.
+The OpenShift 3.0 Documentation provides a way to link:https://docs.openshift.com/container-platform/latest/admin_guide/aggregate_logging.html[use Fluentd to capture and centralize container logs]. This implementation is fairly limiting though as it doesn't fully parse the log files and capture metadata like namespaces, pods names, etc.
 
 ==== Full Metadata Supported Log Aggregation with Fluentd
 

--- a/playbooks/operationalizing/branding_console.adoc
+++ b/playbooks/operationalizing/branding_console.adoc
@@ -165,7 +165,7 @@ NOTE: The indent space is remarkably important. Sometimes, master server can not
 ```
 
 === Web console logo
-After login, it is allowed to modify anything on console style using extended `css/javascrpt/images`. https://docs.openshift.com/enterprise/3.1/install_config/web_console_customization.html[The official document] explain it in detail but it could take a little bit long time to configure due to yaml syntax of master-config.xml. Hence, I recommand to follow this chapter exactly, then you can see brand new logo without trial and error.
+After login, it is allowed to modify anything on console style using extended `css/javascrpt/images`. https://docs.openshift.com/container-platform/latest/install_config/web_console_customization.html[The official document] explains it in detail, but it could take a little bit of time to configure due to yaml syntax of the master-config.xml file. Hence, I recommend following this chapter exactly, then you can see brand new logo without trial and error.
 
 .Workflow
 . Create CSS/Image folder

--- a/playbooks/operationalizing/expose_docker_registry.adoc
+++ b/playbooks/operationalizing/expose_docker_registry.adoc
@@ -11,7 +11,7 @@ toc::[]
 
 OpenShift provides an internal Docker registry for which to serve images for use within the OpenShift environment. It may be desirable to expose this registry for consumption by external entities. This document describes the process of accessing the integrated Docker registry from a source external to the OpenShift environment.
 
-Official documentation on this subject can be found https://docs.openshift.com/enterprise/3.0/install_config/install/docker_registry.html#exposing-the-registry[here].
+Official documentation on this subject can be found https://docs.openshift.com/container-platform/latest/install_config/registry/securing_and_exposing_registry.html#exposing-the-registry[here].
 
 == Prerequisites
 


### PR DESCRIPTION
Fixed broken external links to resolve build failure.  Also updated docs.openshift.com URLs from `/enterprise/{version}/` to `/container-platform/latest/` in order to reduce link maintenance.